### PR TITLE
Include simulation/orogen/vortex

### DIFF
--- a/drivers.autobuild
+++ b/drivers.autobuild
@@ -37,3 +37,5 @@ end
 
 cmake_package "drivers/platform_driver_pcan"
 orogen_package "drivers/orogen/platform_driver_pcan"
+
+cmake_package "drivers/udp"

--- a/simulation.autobuild
+++ b/simulation.autobuild
@@ -1,0 +1,1 @@
+orogen_package "simulation/orogen/vortex"

--- a/source.yml
+++ b/source.yml
@@ -24,6 +24,10 @@ version_control:
     type: git
     url: https://github.com/esa-prl/drivers-orogen-platform_driver_pcan.git
     branch: master
+  - drivers/udp:
+    type: git
+    url: https://github.com/esa-prl/drivers-udp.git
+    branch: master
   - simulation/orogen/vortex:
     type: git
     url: https://github.com/esa-prl/simulation-orogen-vortex.git

--- a/source.yml
+++ b/source.yml
@@ -24,10 +24,6 @@ version_control:
     type: git
     url: https://github.com/esa-prl/drivers-orogen-platform_driver_pcan.git
     branch: master
-  - drivers/udp:
-    type: git
-    url: https://github.com/esa-prl/drivers-udp.git
-    branch: master
   - simulation/orogen/vortex:
     type: git
     url: https://github.com/esa-prl/simulation-orogen-vortex.git


### PR DESCRIPTION
Include simulation/orogen/vortex for ExoTeR Vortex Studio simulations; remove drivers/udp since it should be located in rover-package-set.